### PR TITLE
Fix linking errors caused by the damped_pring function

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -152,7 +152,7 @@ namespace ImSpinner
     
     inline ImColor color_alpha(ImColor c, float alpha) { c.Value.w *= alpha * ImGui::GetStyle().Alpha; return c; }
 
-    float damped_pring (double mass, double stiffness, double damping, double time, float a = PI_DIV_2, float b = PI_DIV_2) {
+    inline float damped_pring (double mass, double stiffness, double damping, double time, float a = PI_DIV_2, float b = PI_DIV_2) {
         double omega = sqrt(stiffness / mass);
         double alpha = damping / (2 * mass);
         double exponent = exp(-alpha * time);


### PR DESCRIPTION
The latest commit of imspinner contains the `damped_pring` function, which is defined like this:
```
float damped_pring (double mass, double stiffness, double damping, double time, float a = PI_DIV_2, float b = PI_DIV_2) {
```
Since it isn't prefixed with `inline`, including this file into multiple `.cpp` files causes a multiple definition linker error like this:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: libUntitledImGuiFramework.a(Global.cpp.o): in function `ImSpinner::damped_pring(double, double, double, double, float, float)':
Global.cpp:(.text+0x0): multiple definition of `ImSpinner::damped_pring(double, double, double, double, float, float)'; CMakeFiles/UntitledTextEditor.dir/Generated/main.cpp.o:main.cpp:(.text+0x0): first defined here
```
I reproduced this locally and on my CI workflows on both Windows(MSVC) and Linux(GCC).