### PR TITLE
Fix linker errors caused by damped_gravity function

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -161,7 +161,7 @@ namespace ImSpinner
         return ((result *= a) + b);
     };
 
-    float damped_gravity(float limtime) {
+    inline float damped_gravity(float limtime) {
         float time = 0.0f, initialHeight = 10.f, height = initialHeight, velocity = 0.f, prtime = 0.0f;
 
         while (height >= 0.0) {


### PR DESCRIPTION
The newly added `damped_gravity` function:
```cpp
float damped_gravity(float limtime) {
```
doesn't have `inline` prefixed to it, resulting in the following types of linker errors when compiling with the header included in multiple compilation units:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/UntitledImGuiFramework.dir/Framework/C/Interfaces/CUtility.cpp.o: in function `ImSpinner::damped_gravity(float)':
CUtility.cpp:(.text+0xd0): multiple definition of `ImSpinner::damped_gravity(float)'; CMakeFiles/UntitledImGuiFramework.dir/Framework/C/Components/CInstance.cpp.o:CInstance.cpp:(.text+0x0): first defined here
```
Reproduced locally and on GitHub, Actions CI on Windows(MSVC) and Linux(GCC).