### PR TITLE
Minor: added missing include <cctype> for 'isalpha()', 'tolower()' funcs

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <cmath>
 #include <map>
+#include <cctype>
 
 #ifdef __has_include
     #if !__has_include(<imgui.h>)


### PR DESCRIPTION
`gcc 9.4.0` produces errors during build - cannot find `isalpha`, `tolower` funcs, since `<cctype>` not included. This small PR fixes it.