### PR TITLE
ImGuiWindowFlags_NavFlattened is deprecated and can cause compilation errors

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -4492,7 +4492,7 @@ namespace ImSpinner
             for(int current_spi = 0; current_spi < num_spinners; current_spi++)
             {
               // BeginChild here needed to restrict item width&height by specific size
-              if( ImGui::BeginChild(100 + current_spi, item_size, false, ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NavFlattened) )
+              if( ImGui::BeginChild(100 + current_spi, item_size, false, ImGuiWindowFlags_NoScrollbar | ImGuiChildFlags_NavFlattened) )
               {
                   draw_spinner(current_spi, widget_size);
               }


### PR DESCRIPTION
Replaced usages of the deprecated `ImGuiWindowFlags_NavFlattened` flag with the new `ImGuiChildFlags_NavFlattened` flag. This will prevent compilation errors for users that disable deprecated parts of the imgui API and will prevent compilation errors for all users in the future.

Testing:
1. Compiled successfully
2. Ran example successfully