### PR TITLE
Compilation error/warning: Force usage of floats in the ease function

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -1479,7 +1479,7 @@ namespace ImSpinner
       for (size_t arc_num = 0; arc_num < arcs; ++arc_num) {
           window->DrawList->PathClear();
           float arc_start = 2 * IM_PI / arcs;
-          float b = ease((ease_mode)mode, start + static_cast<float>(arc_num) * PI_DIV(2) / static_cast<float>(arcs), IM_PI, 1.0f, 0.0f);
+          float b = ease((ease_mode)mode, start + arc_num * PI_DIV(2) / arcs, IM_PI, 1.0f, 0.0f);
           //switch (mode) {
           //case 1: b = start + damped_spring(1, 10.f, 1.0f, , )), 1, 0); break;
           //case 2: b = start + damped_infinity(PI_2 - angle, start).second; break;
@@ -1505,7 +1505,7 @@ namespace ImSpinner
       for (size_t arc_num = 0; arc_num < arcs; ++arc_num) {
         window->DrawList->PathClear();
         ImColor c = color_alpha(color, ImMax(0.1f, arc_num / (float)arcs));
-        float b = ease((ease_mode)mode, start + static_cast<float>(arc_num) * PI_DIV(2) / arcs, IM_PI, 1.0f, 0.0f);
+        float b = ease((ease_mode)mode, start + arc_num * PI_DIV(2) / arcs, IM_PI, 1.0f, 0.0f);
         for (size_t i = 0; i <= num_segments; i++) {
           const float a = start + b + arc_angle * arc_num + (i * angle_offset);
           window->DrawList->PathLineTo(ImVec2(centre.x + ImCos(a) * radius, centre.y + ImSin(a) * radius));

--- a/imspinner.h
+++ b/imspinner.h
@@ -245,7 +245,8 @@ namespace ImSpinner
 
     template<typename ... Args>
     inline float ease(ease_mode mode, Args ... args) {
-        float params[] = {args...}; 
+        static_assert((std::is_same_v<Args, float> && ...), "All arguments should be of type float");
+        float params[] = {args...};
         switch (mode) {
         case e_ease_inoutquad: return ease_inoutquad(params);
         case e_ease_inoutexpo: return ease_inoutexpo(params);
@@ -1478,7 +1479,7 @@ namespace ImSpinner
       for (size_t arc_num = 0; arc_num < arcs; ++arc_num) {
           window->DrawList->PathClear();
           float arc_start = 2 * IM_PI / arcs;
-          float b = ease((ease_mode)mode, start + arc_num * PI_DIV(2) / arcs, IM_PI, 1, 0);
+          float b = ease((ease_mode)mode, start + static_cast<float>(arc_num) * PI_DIV(2) / static_cast<float>(arcs), IM_PI, 1.0f, 0.0f);
           //switch (mode) {
           //case 1: b = start + damped_spring(1, 10.f, 1.0f, , )), 1, 0); break;
           //case 2: b = start + damped_infinity(PI_2 - angle, start).second; break;
@@ -1504,7 +1505,7 @@ namespace ImSpinner
       for (size_t arc_num = 0; arc_num < arcs; ++arc_num) {
         window->DrawList->PathClear();
         ImColor c = color_alpha(color, ImMax(0.1f, arc_num / (float)arcs));
-        float b = ease((ease_mode)mode, start + arc_num * PI_DIV(2) / arcs, IM_PI, 1, 0);
+        float b = ease((ease_mode)mode, start + static_cast<float>(arc_num) * PI_DIV(2) / arcs, IM_PI, 1.0f, 0.0f);
         for (size_t i = 0; i <= num_segments; i++) {
           const float a = start + b + arc_angle * arc_num + (i * angle_offset);
           window->DrawList->PathLineTo(ImVec2(centre.x + ImCos(a) * radius, centre.y + ImSin(a) * radius));


### PR DESCRIPTION
The first line of the `ease` function produces a compilation error on many compilers because the variadic template is not validated to contain all floats:
```cpp
template<typename ... Args>
inline float ease(ease_mode mode, Args ... args) {
    float params[] = {args...};
    // ...
}
```
To fix this, we have to force the list to only compile if it contains only floats. This can be done using the following line before the `params` initialisation:
```cpp
static_assert((std::is_same_v<Args, float> && ...), "All arguments should be of type float");
```
This fold expression only lets the code compile if all arguments in the variadic list are floats.

This PR adds that + patches places where integers were not cast to floats.

> [!NOTE]
> Fold expressions are a C++17 feature. For older compilers a `constexpr` recursive function that uses the same `static_assert` code can be implemented. Example:
> ```cpp
> template<typename T>
> constexpr void validate(T first)
> {
>     static_assert(std::is_same_v<T, float>);
> }
> 
> template<typename T, typename ...T2>
> constexpr void validate(T first, T2... args)
> {
>     static_assert(std::is_same_v<T, float>);
>     validate(args...);
> }
> ```

Not sure if usage of C++11 & C++14 is a priority here, so I will implement the patch without the fold expression if needed.

## Testing
Confirmed to work on Linux with GCC 12.3