### PR TITLE
Fix compilation issues in the latest version of dear imgui

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -1671,7 +1671,10 @@ namespace ImSpinner
         const float start = ImFmod((float)ImGui::GetTime() * speed, PI_2);
         const char *last_symbol = ImGui::FindRenderedTextEnd(text);
         const ImVec2 text_size = ImGui::CalcTextSize(text, last_symbol);
-        const ImFont* font = ImGui::GetCurrentContext()->Font;
+#if IMGUI_VERSION_NUM < 19150
+        const // Newer imgui versions require make the current context's font non-const
+#endif
+        ImFont* font = ImGui::GetCurrentContext()->Font;
 
         ImVec2 pp(centre.x - text_size.x / 2.f, centre.y - text_size.y / 2.f);
 


### PR DESCRIPTION
Version 1.95.5 of dear imgui breaks compilation, because the const qualifier for the context's font was removed. This PR keeps the const qualifier for older versions of dear imgui, while removing it for the latest and newer releases, thus keeping imspinner keeping backwards compatibility.