### PR TITLE
Add missing header that prevented compilation on macOS and Windows

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <map>
 #include <cctype>
+#include <algorithm>
 
 #ifdef __has_include
     #if !__has_include(<imgui.h>)


### PR DESCRIPTION
When compiling imspinner on macOS and Windows, I get the following compiler errors:

1. MSVC
   ```
   imspinner.h(565,29): error C2039: 'clamp': is not a member of 'std'
   imspinner.h(565,29): error C3861: 'clamp': identifier not found
   ```
1. Apple clang:
   ```
   imspinner.h:565:29: error: no member named 'clamp' in namespace 'std'
               radius_k = std::clamp(radius_k, 0.f, 1.f);
   ```

It looks like `std::clamp` is not part of `cmath` on some platforms, which is really confusing 😅

Anyway, the C++ documentation states that it's part of the `algorithm` header so I made this PR to include it in order to fix the issue.