### PR TITLE
Fix compilation issues on libstdc++ v14

### DIFF
--- a/imspinner.h
+++ b/imspinner.h
@@ -260,7 +260,7 @@ namespace ImSpinner
         const float k = 2.1f;
         const float b = 0.09f;
         const float theta = 0.0f;
-        const float w = std::sqrtf(k / ma);
+        const float w = sqrtf(k / ma);
         const float t = ImFmod(*p, 25);
         double x = A * std::exp(-b * t) * std::cos(w * t - theta);
         return x;


### PR DESCRIPTION
I am testing the compilation of my application that uses imspinnner in GitHub Actions using the default `ubuntu-latest` workflow and I got the following compilation error:
```
imspinner.h:263:30: error: ‘sqrtf’ is not a member of ‘std’; did you mean ‘sqrt’?
  263 |         const float w = std::sqrtf(k / ma);
      |                              ^~~~~
      |                              sqrt
```
Turns out that on `ubuntu-latest`(Ubuntu 24.04) the latest `libstdc++` version is 14.2.0, which seems to produce this error, while newer versions do not produce this error. 

It seems like the developers forgot to wrap the function in the `std::` namespace, so the fix is to just remove the `std::` part.