### PR TITLE
imspinner_bars.h: #include <cstdint>  // for uint16_t

### DIFF
--- a/imspinner_bars.h
+++ b/imspinner_bars.h
@@ -9,6 +9,8 @@
  * Spinner<> via imspinner_compat.h (e_st_barchartsine).
  */
 
+#include <cstdint>  // for uint16_t
+
 #ifndef _IMSPINNER_BARS_INTERNAL_
 #include "imspinner.h"
 namespace ImSpinner


### PR DESCRIPTION
Add a missing include (needed on ubuntu / linux)